### PR TITLE
Create snapshots with normalized sizes

### DIFF
--- a/roles/lvm_snapshots/tasks/main.yml
+++ b/roles/lvm_snapshots/tasks/main.yml
@@ -7,6 +7,8 @@
   when: lvm_snapshots_action in ['check', 'create']
 
 - name: Create Snapshot
+  vars:
+    lvm_snapshots_volumes: "{{ lvm_snapshots_check_status.stdout | from_json }}"
   ansible.builtin.include_tasks: create.yml
   when: lvm_snapshots_action == 'create'
 

--- a/tests/create-snapshot.yml
+++ b/tests/create-snapshot.yml
@@ -1,33 +1,16 @@
+- name: Generate snapshot list out of volumes list
+  ansible.builtin.set_fact:
+    _snapshots: "{{ (_snapshots | default([])) + [{'vg': volume_group, 'lv': item.name, 'size': item.size}] }}"
+  loop: "{{ volumes }}"
+
 - name: Create the snapshot
   vars:
     lvm_snapshots_action: create
-    lvm_snapshots_volumes:
-    - vg: "{{ volume_group }}"
-      lv: "{{ volume_name }}"
-      size: "{{ volume_size }}"
+    lvm_snapshots_volumes: "{{ _snapshots }}"
     lvm_snapshots_set_name: "{{ snapshot_set_name }}"
   ansible.builtin.include_role:
     name: lvm_snapshots
 
 - name: Verify that the snapshot was created
-  block:
-  - name: Run lvs
-    ansible.builtin.command: lvs --select 'vg_name = {{ volume_group }} && origin = {{ volume_name }}' --reportformat json
-    register: lvs_response
-    changed_when: false
-  - name: Parse report
-    ansible.builtin.set_fact:
-      lv_snapshot_array: "{{ (lvs_response.stdout | from_json).report[0].lv }}"
-  - name: Verify that the the snapshot exists
-    ansible.builtin.assert:
-      that: (lv_snapshot_array | length) == 1
-      fail_msg: >
-        The snapshot volume was not created
-  - name: Get the snapshot name
-    ansible.builtin.set_fact:
-      snapshot_name: "{{ lv_snapshot_array[0].lv_name | default('n/a') }}"
-  - name: Verify that the the snapshot was named correctly
-    ansible.builtin.assert:
-      that: snapshot_name == volume_name + '_' + snapshot_set_name
-      fail_msg: >
-        Snapshot name '{{ snapshot_name }}' is not as expected {{ volume_name }}_{{ snapshot_set_name }}
+  ansible.builtin.include_tasks: verify-snapshot-created.yml
+  loop: "{{ volumes }}"

--- a/tests/post-test-clean-volume.yml
+++ b/tests/post-test-clean-volume.yml
@@ -1,0 +1,11 @@
+- name: Unmount the "{{ item.directory }}"
+  ansible.posix.mount:
+    path: "{{ item.directory }}"
+    state: absent
+
+- name: Remove the logical volume
+  community.general.lvol:
+    vg: "{{ volume_group }}"
+    lv: "{{ item.name }}"
+    force: true
+    state: absent

--- a/tests/post-test-tasks.yml
+++ b/tests/post-test-tasks.yml
@@ -1,14 +1,6 @@
-- name: Unmount the "{{ test_directory }}"
-  ansible.posix.mount:
-    path: "{{ test_directory }}"
-    state: absent
-
-- name: Remove the logical volume
-  community.general.lvol:
-    vg: "{{ volume_group }}"
-    lv: "{{ volume_name }}"
-    force: true
-    state: absent
+- name: Cleanup the volumes
+  ansible.builtin.include_tasks: post-test-clean-volume.yml
+  loop: "{{ volumes }}"
 
 - name: Remove the volume group
   community.general.lvg:

--- a/tests/pre-test-prepare-volume.yml
+++ b/tests/pre-test-prepare-volume.yml
@@ -1,0 +1,18 @@
+- name: Create the logical volume
+  community.general.lvol:
+    vg: "{{ volume_group }}"
+    lv: "{{ item.name }}"
+    size: "{{ item.size }}"
+    force: true
+
+- name: Format the ext4 filesystem
+  community.general.filesystem:
+    fstype: ext4
+    dev: "/dev/{{ volume_group }}/{{ item.name }}"
+
+- name: Mount the lv on "{{ item.directory }}"
+  ansible.posix.mount:
+    path: "{{ item.directory }}"
+    src: "/dev/{{ volume_group }}/{{ item.name }}"
+    fstype: ext4
+    state: mounted

--- a/tests/pre-test-tasks.yml
+++ b/tests/pre-test-tasks.yml
@@ -18,21 +18,6 @@
     pvs: "/dev/{{ device }}1"
     pesize: 16
 
-- name: Create the logical volume
-  community.general.lvol:
-    vg: "{{ volume_group }}"
-    lv: "{{ volume_name }}"
-    size: "{{ volume_size }}"
-    force: true
-
-- name: Format the ext4 filesystem
-  community.general.filesystem:
-    fstype: ext4
-    dev: "/dev/{{ volume_group }}/{{ volume_name }}"
-
-- name: Mount the lv on "{{ test_directory }}"
-  ansible.posix.mount:
-    path: "{{ test_directory }}"
-    src: "/dev/{{ volume_group }}/{{ volume_name }}"
-    fstype: ext4
-    state: mounted
+- name: Create and prepare the volumes
+  ansible.builtin.include_tasks: pre-test-prepare-volume.yml
+  loop: "{{ volumes }}"

--- a/tests/test-create-snapshot-from-free-playbook.yml
+++ b/tests/test-create-snapshot-from-free-playbook.yml
@@ -1,0 +1,63 @@
+- name: Test creating snapshots as percentage of free
+  hosts: all
+  become: true
+  vars:
+    volume_group: test_vg
+    base_volume_name: test_lv
+    volume_size: 3g
+    base_test_directory: "/mnt/test"
+    snapshot_set_name: demo_snap
+  tasks:
+  - name: Run pre-test steps
+    vars:
+      volumes:
+      - name: "{{ base_volume_name }}-1"
+        size: "{{ volume_size }}"
+        directory: "{{ base_test_directory }}-1"
+      - name: "{{ base_volume_name }}-2"
+        size: "{{ volume_size }}"
+        directory: "{{ base_test_directory }}-2"
+    ansible.builtin.include_tasks: pre-test-tasks.yml
+
+  - name: Create the snapshot
+    vars:
+      volumes:
+      - name: "{{ base_volume_name }}-1"
+        size: 45%FREE
+      - name: "{{ base_volume_name }}-2"
+        size: 45%FREE
+    ansible.builtin.include_tasks: create-snapshot.yml
+
+  - name: Verify the snapshot sizes and cleanup
+    block:
+    - name: Get the size of the created snapshot
+      ansible.builtin.command: lvs --select 'vg_name = {{ volume_group }} && origin = {{ item }}' --units b --reportformat json
+      register: lvs_response
+      changed_when: false
+      loop:
+      - "{{ base_volume_name }}-1"
+      - "{{ base_volume_name }}-2"
+    - name: Parse report
+      ansible.builtin.set_fact:
+        lvs_sizes: "{{ (lvs_sizes | default([])) + [(item.stdout | from_json).report[0].lv[0].lv_size] }}"
+      loop: "{{ lvs_response.results }}"
+    - name: Assert that both snapshots have the same size
+      ansible.builtin.assert:
+        that: lvs_sizes[0] == lvs_sizes[1]
+        fail_msg: "The snapshots were not created with the same size: {{ lvs_sizes[0] }} != {{ lvs_sizes[1] }}"
+        success_msg: "Both snapshots were created with the same size: {{ lvs_sizes[0] }}"
+    always:
+    - name: Remove Snapshot
+      vars:
+        lvm_snapshots_action: remove
+        lvm_snapshots_set_name: "{{ snapshot_set_name }}"
+      ansible.builtin.include_role:
+        name: lvm_snapshots
+    - name: Cleanup
+      vars:
+        volumes:
+        - name: "{{ base_volume_name }}-1"
+          directory: "{{ base_test_directory }}-1"
+        - name: "{{ base_volume_name }}-2"
+          directory: "{{ base_test_directory }}-2"
+      ansible.builtin.include_tasks: post-test-tasks.yml

--- a/tests/test-remove-playbook.yml
+++ b/tests/test-remove-playbook.yml
@@ -1,12 +1,12 @@
-- name: Demo playbook
+- name: Test removing snapshots after creating them
   hosts: all
   become: true
   vars:
     volume_group: test_vg
-    volume_name: test_lv
-    volume_size: 1g
-    test_directory: "/mnt/test"
-    test_file: "{{ mount_path }}/foo.txt"
+    volumes:
+    - name: test_lv
+      size: 1g
+      directory: /mnt/test
     snapshot_set_name: demo_snap
     lvm_snapshots_snapshot_autoextend_threshold: 80
     lvm_snapshots_snapshot_autoextend_percent: 15
@@ -25,6 +25,8 @@
       name: lvm_snapshots
 
   - name: Verify that the snapshot no longer exist
+    vars:
+      volume_name: test_lv
     ansible.builtin.include_tasks: verify-snapshot-not-exist.yml
 
   - name: Cleanup

--- a/tests/test-resize-too-small-playbook.yml
+++ b/tests/test-resize-too-small-playbook.yml
@@ -1,11 +1,13 @@
-- name: Demo playbook
+- name: Test trying to resize the volume to a size smaller than what the filesystem uses
   hosts: all
   become: true
   vars:
     volume_group: test_vg
-    volume_name: test_lv
-    volume_size: 4g
     test_directory: "/mnt/test"
+    volumes:
+    - name: test_lv
+      size: 4g
+      directory: "{{ test_directory }}"
     test_file_path: "{{ test_directory }}/foo.txt"
     test_file_size: 2g
   tasks:
@@ -24,7 +26,7 @@
         lvm_snapshots_action: check_for_resize
         lvm_snapshots_volumes:
         - vg: "{{ volume_group }}"
-          lv: "{{ volume_name }}"
+          lv: test_lv
           size: 1g
       ansible.builtin.include_role:
         name: lvm_snapshots

--- a/tests/test-revert-playbook.yml
+++ b/tests/test-revert-playbook.yml
@@ -1,11 +1,13 @@
-- name: Demo playbook
+- name: Test revering to the snapshots
   hosts: all
   become: true
   vars:
     volume_group: test_vg
-    volume_name: test_lv
-    volume_size: 1g
     test_directory: "/mnt/test"
+    volumes:
+    - name: test_lv
+      size: 1g
+      directory: "{{ test_directory }}"
     test_file: "{{ test_directory }}/foo.txt"
     snapshot_set_name: demo_snap
   tasks:
@@ -54,6 +56,8 @@
       failed_when: ls_response.rc == 0
 
   - name: Verify that the snapshot no longer exists
+    vars:
+      volume_name: test_lv
     ansible.builtin.include_tasks: verify-snapshot-not-exist.yml
 
   - name: Cleanup

--- a/tests/test-snapshot-too-big-playbook.yml
+++ b/tests/test-snapshot-too-big-playbook.yml
@@ -1,12 +1,12 @@
-- name: Demo playbook
+- name: Test trying to create to big a snapshot
   hosts: all
   become: true
   vars:
     volume_group: test_vg
-    volume_name: test_lv
-    volume_size: 8g
-    test_directory: "/mnt/test"
-    test_file: "{{ mount_path }}/foo.txt"
+    volumes:
+    - name: test_lv
+      size: 8g
+      directory: /mnt/test
     snapshot_set_name: demo_snap
     lvm_snapshots_snapshot_autoextend_threshold: 80
     lvm_snapshots_snapshot_autoextend_percent: 15
@@ -20,6 +20,8 @@
       ansible.builtin.include_tasks: create-snapshot.yml
     always:
     - name: Verify that the snapshot does not exist
+      vars:
+        volume_name: test_lv
       ansible.builtin.include_tasks: verify-snapshot-not-exist.yml
     - name: Cleanup
       ansible.builtin.include_tasks: post-test-tasks.yml
@@ -32,6 +34,6 @@
         that:
         - lvm_snapshots_check_failure_json is defined
         - lvm_snapshots_check_failure_json.test_vg
-        - lvm_snapshots_check_failure_json.test_vg.size == 9642201579.52
-        - lvm_snapshots_check_failure_json.test_vg.free == 1056964608.0
+        - lvm_snapshots_check_failure_json.test_vg.size == 9646899200
+        - lvm_snapshots_check_failure_json.test_vg.free == 1056964608
         - lvm_snapshots_check_failure_json.test_vg.requested_size == 8589934592

--- a/tests/verify-snapshot-created.yml
+++ b/tests/verify-snapshot-created.yml
@@ -1,0 +1,24 @@
+- name: Run lvs
+  ansible.builtin.command: lvs --select 'vg_name = {{ volume_group }} && origin = {{ item.name }}' --reportformat json
+  register: lvs_response
+  changed_when: false
+
+- name: Parse report
+  ansible.builtin.set_fact:
+    lv_snapshot_array: "{{ (lvs_response.stdout | from_json).report[0].lv }}"
+
+- name: Verify that the the snapshot exists
+  ansible.builtin.assert:
+    that: (lv_snapshot_array | length) == 1
+    fail_msg: >
+      The snapshot for {{ item.name }} was not created
+
+- name: Get the snapshot name
+  ansible.builtin.set_fact:
+    snapshot_name: "{{ lv_snapshot_array[0].lv_name | default('n/a') }}"
+
+- name: Verify that the the snapshot was named correctly
+  ansible.builtin.assert:
+    that: snapshot_name == item.name + '_' + snapshot_set_name
+    fail_msg: >
+      Snapshot name '{{ snapshot_name }}' is not as expected {{ item.name }}_{{ snapshot_set_name }}


### PR DESCRIPTION
check.py - print new volumes array with normalized values when successful
role - use the normalized array instead of the one passed by the user
Test Infra - Allow creating multiple volumes and snapshots 
Tests: Add test to verify that FREE based snapshots with the same percentage get the same size