### PR TITLE
Minor var changes

### DIFF
--- a/changelogs/fragments/minor-var-changes.yml
+++ b/changelogs/fragments/minor-var-changes.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - Changed the lvm_snapshots_boot_backup var default to false
+  - Removed unimplemented lvm_snapshots_use_boom var from the docs

--- a/roles/lvm_snapshots/README.md
+++ b/roles/lvm_snapshots/README.md
@@ -1,7 +1,7 @@
 # lvm_snapshots role
 
 
-The `lvm_snapshots` role is used to control the creation and rollback for a defined set of LVM snapshot volumes. In addition, it can optionally save the Grub configuration and image files under /boot, create a snapshot boom entry, and configure settings to enable the LVM snapshot autoextend capability.
+The `lvm_snapshots` role is used to control the creation and rollback for a defined set of LVM snapshot volumes. In addition, it can optionally save the Grub configuration and image files under /boot and configure settings to enable the LVM snapshot autoextend capability.
 
 The role is designed to support the automation of RHEL in-place upgrades, but can also be used to reduce the risk of more mundane system maintenance activities.
 
@@ -30,15 +30,11 @@ The `revert` action will verify that all snapshots in the set are still active s
 
 ### `lvm_snapshots_boot_backup`
 
-Boolean to specify that the `create` action should preserve the Grub configuration and image files under /boot required for booting the default kernel. The preserved files will be restored with a `revert` action and they will be deleted with a `remove` action. The files are preserved in a compressed tar archive at `/root/boot-backup-<lvm_snapshots_set_name>.tgz`. Default is true.
+Boolean to specify that the `create` action should preserve the Grub configuration and image files under /boot required for booting the default kernel. The preserved files will be restored with a `revert` action and they will be deleted with a `remove` action. The files are preserved in a compressed tar archive at `/root/boot-backup-<lvm_snapshots_set_name>.tgz`. Default is false.
 
 > **Warning**
 >
 > When automating RHEL in-place upgrades, do not perform a Grub to Grub2 migration as part of your upgrade playbook. It will invalidate your boot backup and cause a subsequent `revert` action to fail. For example, if you are using the [`upgrade`](https://github.com/redhat-cop/infra.leapp/tree/main/roles/upgrade#readme) role from the [`infra.leapp`](https://github.com/redhat-cop/infra.leapp) collection, do not set `update_grub_to_grub_2` to `true`. Grub to Grub2 migration should only be performed after the `remove` action has been performed to delete the snapshots and boot backup.
-
-### `lvm_snapshots_use_boom`
-
-Boolean to specify that a boom profile will be created to add a Grub boot entry for the snapshot set. Default is true.
 
 ### `lvm_snapshots_snapshot_autoextend_threshold`
 
@@ -72,7 +68,7 @@ To create thin provisioned snapshot of a thin provisioned volume, omit the `size
 
 ### Create snapshots
 
-Perform space check and fail of there will not be enough space for all the snapshots in the set. If there is sufficient space, proceed to create snapshots for the listed logical volumes. Each snapshot will be sized to 20% of the origin volume size. Snapshot autoextend settings are configured to enable free space in the volume group to be allocated to any snapshot that may exceed 70% usage in the future. A boom profile will be created for the snapshot and required images files under /boot will be preserved.
+Perform space check and fail of there will not be enough space for all the snapshots in the set. If there is sufficient space, proceed to create snapshots for the listed logical volumes. Each snapshot will be sized to 20% of the origin volume size. Snapshot autoextend settings are configured to enable free space in the volume group to be allocated to any snapshot that may exceed 70% usage in the future. Files under /boot will be preserved.
 
 ```yaml
 - hosts: all
@@ -83,19 +79,18 @@ Perform space check and fail of there will not be enough space for all the snaps
       lvm_snapshots_snapshot_autoextend_threshold: 70
       lvm_snapshots_snapshot_autoextend_percent: 20
       lvm_snapshots_boot_backup: true
-      lvm_snapshots_use_boom: true
       lvm_snapshots_volumes:
         - vg: rootvg
           lv: root
-          size: 20%ORIGIN
+          size: 2G
         - vg: rootvg
           lv: var
-          size: 20%ORIGIN
+          size: 2G
 ```
 
 ### Rollback
 
-This playbook rolls back the host using the snapshots created above. After verifying that all snapshots are still valid, each logical volume in the snapshot set is merged. The image files under /boot will be restored and the boom profile will be deleted. Then the host will be rebooted.
+This playbook rolls back the host using the snapshots created above. After verifying that all snapshots are still valid, each logical volume in the snapshot set is merged. The image files under /boot will be restored and then the host will be rebooted.
 
 ```yaml
 - hosts: all
@@ -104,12 +99,11 @@ This playbook rolls back the host using the snapshots created above. After verif
       lvm_snapshots_set_name: ripu
       lvm_snapshots_action: revert
       lvm_snapshots_boot_backup: true
-      lvm_snapshots_use_boom: true
 ```
 
 ### Commit
 
-A commit playbook is used when users are comfortable the snapshots are not needed any longer. Each snapshot in the snapshot set is removed, the preserved image files under /boot are unlinked and the boom profile is deleted.
+A commit playbook is used when users are comfortable the snapshots are not needed any longer. Each snapshot in the snapshot set is removed and the backed up image files from /boot are deleted.
 
 ```yaml
 - hosts: all
@@ -118,5 +112,4 @@ A commit playbook is used when users are comfortable the snapshots are not neede
       lvm_snapshots_set_name: ripu
       lvm_snapshots_action: remove
       lvm_snapshots_boot_backup: true
-      lvm_snapshots_use_boom: true
 ```

--- a/roles/lvm_snapshots/defaults/main.yml
+++ b/roles/lvm_snapshots/defaults/main.yml
@@ -1,3 +1,2 @@
 lvm_snapshots_volumes: []
-lvm_snapshots_use_boom: true
-lvm_snapshots_boot_backup: true
+lvm_snapshots_boot_backup: false

--- a/tests/fill-snapshot.yml
+++ b/tests/fill-snapshot.yml
@@ -34,7 +34,7 @@
     ansible.builtin.assert:
       that: (_retry_count|int) < (snapshot_max_retry|int)
       fail_msg: "Ended after {{ snapshot_max_retry }} retries"
-      success_msg: "Volume is not full enought ({{ _snapshot_data_percent }}) - Run again..."
+      success_msg: "Volume is not full enough ({{ _snapshot_data_percent }}) - Run again..."
 
   - name: Include the same tasks file again
     ansible.builtin.include_tasks: fill-snapshot.yml

--- a/tests/test-drain-snapshot.yml
+++ b/tests/test-drain-snapshot.yml
@@ -29,7 +29,7 @@
     ansible.builtin.include_role:
       name: lvm_snapshots
 
-  - name: Verify that the snapshot was completly drained
+  - name: Verify that the snapshot was completely drained
     block:
     - name: Verify that the snapshot no longer exists
       vars:


### PR DESCRIPTION
As discussed with the team, we're removing removing the unimplemented `lvm_snapshots_use_boom` var from the docs and changing the `lvm_snapshots_boot_backup` default to `false`.