### PR TITLE
Boot backup fix

### DIFF
--- a/changelogs/fragments/wrong-kernel.yml
+++ b/changelogs/fragments/wrong-kernel.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Wrong kernel version booting after rolling back

--- a/roles/lvm_snapshots/tasks/create.yml
+++ b/roles/lvm_snapshots/tasks/create.yml
@@ -44,7 +44,10 @@
     - "/boot/System.map-{{ ansible_kernel }}"
     - "/boot/symvers-{{ ansible_kernel }}.gz"
     - "/boot/config-{{ ansible_kernel }}"
+    - "/boot/.vmlinuz-{{ ansible_kernel }}.hmac"
     - /boot/grub/grub.conf
     - /boot/grub2/grub.cfg
+    - /boot/grub2/grubenv
+    - /boot/loader/entries
     - /boot/efi/EFI/redhat/grub.cfg
   when: lvm_snapshots_boot_backup


### PR DESCRIPTION
The boot backup did not include all the files required when host was using [Boot Loader Specification](https://uapi-group.org/specifications/specs/boot_loader_specification/) configuration. 