### PR TITLE
Bls fixes

### DIFF
--- a/roles/lvm_snapshots/tasks/create.yml
+++ b/roles/lvm_snapshots/tasks/create.yml
@@ -30,6 +30,7 @@
 
 - name: Add grubenv saved_entry
   ansible.builtin.shell: 'grubby --set-default-index=$(grubby --default-index)'
+  changed_when: true
   when: grubenv.found is defined and grubenv.found == 0
 
 - name: Create snapshots

--- a/roles/lvm_snapshots/tasks/create.yml
+++ b/roles/lvm_snapshots/tasks/create.yml
@@ -19,7 +19,7 @@
     when: ((lvm_snapshots_new_lvm_config | trim) | length) > 0
 
 - name: Check for grubenv saved_entry
-  lineinfile:
+  ansible.builtin.lineinfile:
     name: /boot/grub2/grubenv
     regexp: ^saved_entry=
     state: absent

--- a/roles/lvm_snapshots/tasks/create.yml
+++ b/roles/lvm_snapshots/tasks/create.yml
@@ -18,6 +18,9 @@
     changed_when: true
     when: ((lvm_snapshots_new_lvm_config | trim) | length) > 0
 
+- name: Force grubenv saved_entry
+  ansible.builtin.shell: 'grubby --set-default-index=$(grubby --default-index)'
+
 - name: Create snapshots
   community.general.lvol:
     vg: "{{ item.vg }}"

--- a/roles/lvm_snapshots/tasks/create.yml
+++ b/roles/lvm_snapshots/tasks/create.yml
@@ -18,8 +18,19 @@
     changed_when: true
     when: ((lvm_snapshots_new_lvm_config | trim) | length) > 0
 
-- name: Force grubenv saved_entry
+- name: Check for grubenv saved_entry
+  lineinfile:
+    name: /boot/grub2/grubenv
+    regexp: ^saved_entry=
+    state: absent
+  check_mode: true
+  changed_when: false
+  failed_when: false
+  register: grubenv
+
+- name: Add grubenv saved_entry
   ansible.builtin.shell: 'grubby --set-default-index=$(grubby --default-index)'
+  when: grubenv.found is defined and grubenv.found == 0
 
 - name: Create snapshots
   community.general.lvol:


### PR DESCRIPTION
Fixing another way the wrong kernel version will be seen booting after rolling back. This failure mode happens when there is no `saved_entry` configured in the `/boot/grub2/grubenv` file. When this is true, the default boot entry is undefined and index 0 is booted by default. The issue comes when a newer BLS kernel entry has been dropped under the `/boot/loader/entries` directory making it the new default. To get around this, we add a saved_entry configuration to grubenv if it doesn't already exist before creating the boot backup and snapshots. 