### PR TITLE
Fix lvm grub

### DIFF
--- a/changelogs/fragments/fix-lvm-grub.yml
+++ b/changelogs/fragments/fix-lvm-grub.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Grub needs reinstall if /boot is on LVM

--- a/roles/lvm_snapshots/tasks/revert.yml
+++ b/roles/lvm_snapshots/tasks/revert.yml
@@ -24,6 +24,24 @@
 - name: Reboot
   ansible.builtin.reboot:
 
+- name: Check if /boot is on LVM
+  ansible.builtin.command: "grub2-probe --target=abstraction /boot"
+  changed_when: false
+  failed_when: false
+  register: boot_abstraction
+
+- name: Reinstall Grub to boot device
+  when: boot_abstraction.stdout == 'lvm'
+  block:
+  - name: Get boot device
+    ansible.builtin.shell: "lsblk -spnlo name $(grub2-probe --target=device /boot)"
+    changed_when: false
+    register: boot_dev_deps
+
+  - name: Run grub2-install
+    ansible.builtin.command: "grub2-install {{ boot_dev_deps.stdout_lines | last }}"
+    changed_when: true
+
 - name: Remove boot backup
   ansible.builtin.file:
     path: "/root/boot-backup-{{ lvm_snapshots_set_name }}.tgz"


### PR DESCRIPTION
When the /boot directory is stored on an LVM logical volume, the entire contents of /boot is rolled back by the snapshot merge. This causes the grub stage 2 pointer in the MBR to be incorrect if it was changed during the upgrade. Doing `grub2-install` after rolling back fixes this. 